### PR TITLE
Connection handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/client/data

--- a/client/main.go
+++ b/client/main.go
@@ -10,17 +10,22 @@ func main() {
 	// cliente basico para testear, a refactorizar
 	conn, err := net.Dial("tcp", "localhost:9001")
 	if err != nil {
-		fmt.Println("Error:", err)
+		fmt.Println("Error connecting to server:", err)
 		return
 	}
 	defer conn.Close()
 
 	m := middleware.NewMessageHandler(conn)
-	m.SendMessage([]byte("Hello, world!"))
+
+	err = m.SendMessage([]byte("Hello, world!"))
+	if err != nil {
+		fmt.Println("Error sending message:", err)
+		return
+	}
 
 	msg, err := m.ReceiveMessage()
 	if err != nil {
-		fmt.Println("Error:", err)
+		fmt.Println("Error receiving message:", err)
 		return
 	}
 

--- a/client/main.go
+++ b/client/main.go
@@ -17,11 +17,14 @@ func main() {
 
 	m := middleware.NewMessageHandler(conn)
 
-	err = m.SendMessage([]byte("Hello, world!"))
+	message := "Hello, world!"
+	err = m.SendMessage([]byte(message))
 	if err != nil {
 		fmt.Println("Error sending message:", err)
 		return
 	}
+
+	fmt.Println("Sent:", message)
 
 	msg, err := m.ReceiveMessage()
 	if err != nil {

--- a/client/main.go
+++ b/client/main.go
@@ -1,15 +1,28 @@
 package main
 
 import (
+	"distribuidos/tp1/middleware"
 	"fmt"
-	"log"
-	"os"
+	"net"
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		log.Fatalln("expected client number as first argument")
+	// cliente basico para testear, a refactorizar
+	conn, err := net.Dial("tcp", "localhost:9001")
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
 	}
-	n := os.Args[1]
-	fmt.Printf("Hello, client %v.\n", n)
+	defer conn.Close()
+
+	m := middleware.NewMessageHandler(conn)
+	m.SendMessage([]byte("Hello, world!"))
+
+	msg, err := m.ReceiveMessage()
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
+
+	fmt.Println("Received:", msg)
 }

--- a/gateway/connectionHandler.go
+++ b/gateway/connectionHandler.go
@@ -1,6 +1,51 @@
 package main
 
-func (g *gateway) startConnectionHandler() {
-	// aca iniciaria el hilo del connection handler
-	// asignado: ro
+import (
+	"distribuidos/tp1/middleware"
+	"fmt"
+	"log"
+	"net"
+)
+
+const PACKET_SIZE = 4
+
+func (g *gateway) StartConnectionHandler() {
+	address := fmt.Sprintf(":%d", g.config.connectionEndpointPort)
+	listener, err := net.Listen("tcp", address)
+
+	if err != nil {
+		log.Fatalf("failed to bind socket: %v", err)
+	}
+	defer listener.Close()
+
+	fmt.Println("Gateway is listening on port ", g.config.connectionEndpointPort)
+
+	for {
+		conn, err := listener.Accept()
+
+		fmt.Println("Client connected: ", conn.RemoteAddr().String())
+
+		if err != nil {
+			log.Fatalf("Error:", err)
+			continue
+		}
+
+		go g.handleClient(conn)
+	}
+}
+
+func (g *gateway) handleClient(conn net.Conn) {
+	defer conn.Close()
+
+	m := middleware.NewMessageHandler(conn)
+
+	for {
+		msg, err := m.ReceiveMessage()
+		if err != nil {
+			log.Fatalf("Failed to read message: %v", err)
+			return
+		}
+
+		fmt.Printf("Received: %s\n", msg)
+	}
 }

--- a/gateway/connectionHandler.go
+++ b/gateway/connectionHandler.go
@@ -7,8 +7,6 @@ import (
 	"net"
 )
 
-const PACKET_SIZE = 4
-
 func (g *gateway) startConnectionHandler() {
 	address := fmt.Sprintf(":%d", g.config.connectionEndpointPort)
 	listener, err := net.Listen("tcp", address)
@@ -23,12 +21,12 @@ func (g *gateway) startConnectionHandler() {
 	for {
 		conn, err := listener.Accept()
 
-		fmt.Println("Client connected: ", conn.RemoteAddr().String())
-
 		if err != nil {
 			fmt.Println("Error:", err)
 			continue
 		}
+
+		fmt.Println("Client connected: ", conn.RemoteAddr().String())
 
 		go g.handleClient(conn)
 	}

--- a/gateway/connectionHandler.go
+++ b/gateway/connectionHandler.go
@@ -9,7 +9,7 @@ import (
 
 const PACKET_SIZE = 4
 
-func (g *gateway) StartConnectionHandler() {
+func (g *gateway) startConnectionHandler() {
 	address := fmt.Sprintf(":%d", g.config.connectionEndpointPort)
 	listener, err := net.Listen("tcp", address)
 

--- a/gateway/connectionHandler.go
+++ b/gateway/connectionHandler.go
@@ -26,7 +26,7 @@ func (g *gateway) StartConnectionHandler() {
 		fmt.Println("Client connected: ", conn.RemoteAddr().String())
 
 		if err != nil {
-			log.Fatalf("Error:", err)
+			fmt.Println("Error:", err)
 			continue
 		}
 

--- a/gateway/connectionHandler.go
+++ b/gateway/connectionHandler.go
@@ -42,6 +42,10 @@ func (g *gateway) handleClient(conn net.Conn) {
 	for {
 		msg, err := m.ReceiveMessage()
 		if err != nil {
+			if err.Error() == "EOF" {
+				fmt.Println("Client disconnected")
+				return
+			}
 			log.Fatalf("Failed to read message: %v", err)
 			return
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -7,13 +7,13 @@ type gateway struct {
 	// ej: clientes activos?
 }
 
-func NewGateway(config config) *gateway {
+func newGateway(config config) *gateway {
 	return &gateway{
 		config: config,
 	}
 }
 
-func (g *gateway) Start() {
-	go g.StartConnectionHandler()
+func (g *gateway) start() {
+	go g.startConnectionHandler()
 	go g.startDataHandler()
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -1,5 +1,10 @@
 package main
 
+import (
+	"fmt"
+	"sync"
+)
+
 type gateway struct {
 	config config
 	// aca pueden ir los campos en comun
@@ -14,6 +19,12 @@ func newGateway(config config) *gateway {
 }
 
 func (g *gateway) start() {
+	var wg sync.WaitGroup
+
+	wg.Add(2)
 	go g.startConnectionHandler()
 	go g.startDataHandler()
+
+	wg.Wait()
+	fmt.Println("All goroutines have completed.")
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -7,13 +7,13 @@ type gateway struct {
 	// ej: clientes activos?
 }
 
-func newGateway(config config) *gateway {
+func NewGateway(config config) *gateway {
 	return &gateway{
 		config: config,
 	}
 }
 
-func (g *gateway) start() {
-	go g.startConnectionHandler()
+func (g *gateway) Start() {
+	go g.StartConnectionHandler()
 	go g.startDataHandler()
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -18,11 +18,11 @@ func getConfig() (config, error) {
 }
 
 func main() {
-	config, err := getConfig()
+	cfg, err := getConfig()
 	if err != nil {
 		log.Fatalf("failed to read config: %v", err)
 	}
 
-	gateway := newGateway(config)
-	gateway.start()
+	gateway := NewGateway(cfg)
+	gateway.Start()
 }

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -23,6 +23,6 @@ func main() {
 		log.Fatalf("failed to read config: %v", err)
 	}
 
-	gateway := NewGateway(cfg)
-	gateway.Start()
+	gateway := newGateway(cfg)
+	gateway.start()
 }

--- a/middleware/message-handler.go
+++ b/middleware/message-handler.go
@@ -1,0 +1,73 @@
+package middleware
+
+import (
+	"net"
+	"encoding/binary"
+)
+
+const PACKET_SIZE = 4
+
+type MessageHandler struct {
+	conn net.Conn
+}
+
+func NewMessageHandler(conn net.Conn) *MessageHandler {
+	return &MessageHandler{
+		conn: conn,
+	}
+}
+
+func (m *MessageHandler) ReceiveMessage() (string, error) {
+	size_bytes, err := m.readMessage(PACKET_SIZE)
+	if err != nil {
+		return "", err
+	}
+
+	size := int32(binary.BigEndian.Uint32(size_bytes))
+
+	msg, err := m.readMessage(size)
+	return string(msg), err
+}
+
+func (m *MessageHandler) SendMessage(msg []byte) error {
+	err := m.sendHeader(int32(len(msg)))
+
+	if err != nil {
+		return err
+	}
+
+	totalSent := 0
+
+	for totalSent < len(msg) {
+		n, err := m.conn.Write((msg[totalSent:]))
+		if err != nil {
+			return err
+		}
+		totalSent += n
+	}
+
+	return nil
+}
+
+func (m *MessageHandler) readMessage(size int32) ([]byte, error) {
+	buf := make([]byte, size)
+	totalRead := 0
+
+	for int32(totalRead) < size {
+		n, err := m.conn.Read(buf[totalRead:])
+		if err != nil {
+			return nil, err
+		}
+		totalRead += n
+	}
+	return buf, nil
+}
+
+func (m *MessageHandler) sendHeader(size int32) error {
+	err := binary.Write(m.conn, binary.BigEndian, int32(size))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/middleware/message-handler.go
+++ b/middleware/message-handler.go
@@ -1,8 +1,8 @@
 package middleware
 
 import (
-	"net"
 	"encoding/binary"
+	"net"
 )
 
 const PACKET_SIZE = 4


### PR DESCRIPTION
Servidor básico para handlear requests tcp. Agregué un "middleware" para enviar y recibir mensajes con un header que indica el tamaño del payload, que lo usa tanto el gateway como el cliente