### PR TITLE
Add diff test for language

### DIFF
--- a/cmd/detect-language/diff.sh
+++ b/cmd/detect-language/diff.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+: "${N:=100}"
+
+delta -s \
+      <(head -n "$N" english_reviews_go.csv) \
+      <(head -n "$N" english_reviews_py.csv)

--- a/cmd/detect-language/main.go
+++ b/cmd/detect-language/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"distribuidos/tp1/server/middleware"
+	"distribuidos/tp1/utils"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/rylans/getlang"
+)
+
+func main() {
+	inputFile, err := os.Open(".data/reviews.csv")
+	utils.Expect(err, "failed to open file")
+	outputFile, err := os.Create("english_reviews_go.csv")
+	utils.Expect(err, "failed to open file")
+
+	reader := csv.NewReader(inputFile)
+	reader.FieldsPerRecord = -1
+	_, _ = reader.Read()
+
+	writer := csv.NewWriter(outputFile)
+
+	for {
+		record, err := reader.Read()
+		if errors.Is(err, &csv.ParseError{}) {
+			continue
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		utils.Expect(err, "failed to read file")
+
+		review, err := reviewFromFullRecord(record)
+		if err != nil {
+			continue
+		}
+
+		info := getlang.FromString(review.Text)
+		if info.LanguageName() == "English" {
+			err = writer.Write([]string{
+				strconv.Itoa(int(review.AppID)),
+				review.Text,
+			})
+			utils.Expect(err, "failed to write file")
+		}
+	}
+
+	writer.Flush()
+}
+
+var emptyReviewTextError = errors.New("review text should not be empty")
+
+func reviewFromFullRecord(record []string) (review middleware.Review, err error) {
+	if len(record) < 4 {
+		err = fmt.Errorf("expected 4 fields, got %v", len(record))
+		return
+	}
+	appId, err := strconv.Atoi(record[0])
+	if err != nil {
+		return
+	}
+	score, err := strconv.Atoi(record[3])
+	if err != nil {
+		return
+	}
+
+	review.AppID = uint64(appId)
+	review.Text = record[2]
+	if review.Text == "" {
+		err = emptyReviewTextError
+		return
+	}
+	review.Score = middleware.Score(score)
+
+	return
+}

--- a/cmd/detect-language/main.py
+++ b/cmd/detect-language/main.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import langid
+
+try:
+    import os
+    os.remove("english_reviews_py.csv")
+except:
+    pass
+
+with pd.read_csv('.data/reviews.csv', chunksize=1024) as reader:
+    for reviews in reader:
+        reviews_columns = ['app_id', 'review_text']
+        reviews = reviews.filter(reviews_columns, axis="columns").dropna()
+        reviews['review_text'] = reviews['review_text'].astype(str)
+        reviews = reviews.head(100)
+
+        def detect_language(texto):
+            language, _ = langid.classify(texto)
+            return language
+
+        reviews["review_language"] = reviews['review_text'].apply(detect_language)
+        reviews = reviews[reviews["review_language"] == "en"] # type: ignore
+        reviews = reviews.filter(reviews_columns, axis="columns")
+
+        reviews.to_csv("english_reviews_py.csv", mode='a', header=False, index=False)


### PR DESCRIPTION
Agrega scripts para comparar langauge detector de Go vs Py

ejemplo: Izquierda es Go, derecha es Python
![image](https://github.com/user-attachments/assets/889c61b9-589e-4433-8397-3c545d08f921)

En las primeras 100 filas ya se pueden ver diferencias