### PR TITLE
Script para generar dataset reducido

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 bin
 .data
-.results
 .results-*
 .build
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin
 .data
+.results
 .results-*
 .build

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ deps:
 build: deps
 	go build -o .build/ ./cmd/...
 
-	# todo: eventualy remove these
-	go build -o bin/top-n-reviews-joiner ./server/joiners/topNReviewsJoiner
-
 .PHONY: build
 
 docker-build:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <!--toc:start-->
 - [Configurar cantidad de nodos por query](#configurar-cantidad-de-nodos-por-query)
-- [Ejecucion con Docker](#ejecucion-con-docker)
-- [Comparacion de resultados](#comparacion-de-resultados)
+- [Ejecución con Docker](#ejecución-con-docker)
+- [Comparación de resultados](#comparación-de-resultados)
 - [Usar dataset reducido](#usar-dataset-reducido)
 <!--toc:end-->
 
@@ -13,7 +13,7 @@ Para actualizar el archivo `compose.yaml` con la cantidad de nodos deseada, modi
 make write-compose
 ```
 
-## Ejecucion con Docker
+## Ejecución con Docker
 
 Para levantar los procesos, ejecutar:
 ```bash
@@ -43,7 +43,7 @@ Luego ejecutar:
 ./cmd/detect-language/diff.sh
 ```
 
-## Comparacion de resultados
+## Comparación de resultados
 
 Para comparar los resultados, primero hay que obtener los valores de referencia. Tenemos un script de Python que los resuelve, pero necesitamos usar el mismo detector de lenguaje, para asegurar que los resultados sean los mismo. Para eso, ejecutamos:
 ```bash
@@ -68,7 +68,7 @@ Primero, tenemos que generar un dataset reducido de datos. Para eso, ejecutamos:
 go run ./scripts/reduce/main.go
 ```
 
-Despues, tenemos que modificar el compose para que use el dataset reducido. Tenemos que cambiar cual carpeta de los datos se bindea al contenedor del cliente. Se puede hacer manualmente, o automaticamente ejecutando:
+Después, tenemos que modificar el compose para que use el dataset reducido. Tenemos que cambiar cuál carpeta de los datos se bindea al contenedor del cliente. Se puede hacer manualmente, o automáticamente ejecutando:
 ```bash
 sed -i 's|./.data:/.data|./.data-reduced:/.data|' ./scripts/compose/main.go # linux
 sed -i '' 's|./.data:/.data|./.data-reduced:/.data|' ./scripts/compose/main.go # osx
@@ -79,4 +79,4 @@ Luego, regeneramos el compose:
 make write-compose
 ```
 
-Luego de ejecutar el sistema, podemos adaptar la seccion de [comparacion de resultados](#comparacion-de-resultados) para utilizar el dataset reducido.
+Luego de ejecutar el sistema, podemos adaptar la sección de [comparación de resultados](#comparación-de-resultados) para utilizar el dataset reducido.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Distribuidos - TP1
 
+<!--toc:start-->
+- [Configurar cantidad de nodos por query](#configurar-cantidad-de-nodos-por-query)
+- [Ejecucion con Docker](#ejecucion-con-docker)
+- [Comparacion de resultados](#comparacion-de-resultados)
+- [Usar dataset reducido](#usar-dataset-reducido)
+<!--toc:end-->
+
 ## Configurar cantidad de nodos por query
 Para actualizar el archivo `compose.yaml` con la cantidad de nodos deseada, modificar las constantes del script `cmd/compose/main.go` y luego ejecutar el comando:
 ```bash
@@ -45,7 +52,7 @@ go run ./scripts/filter-english-negative/main.go .data/reviews.csv .data/reviews
 
 Luego, resolvemos las consultas localmente, ejecutando:
 ```bash
-python ./scripts/solve.py
+python ./scripts/solve.py .data/ .py-results/
 ```
 Este guardara los resultados correctos en `.py-results/`
 
@@ -53,3 +60,23 @@ Para compararlos, ejecutamos:
 ```bash
 ./scripts/compare.sh .results/ .py-results/
 ```
+
+## Usar dataset reducido
+
+Primero, tenemos que generar un dataset reducido de datos. Para eso, ejecutamos:
+```bash
+go run ./scripts/reduce/main.go
+```
+
+Despues, tenemos que modificar el compose para que use el dataset reducido. Tenemos que cambiar cual carpeta de los datos se bindea al contenedor del cliente. Se puede hacer manualmente, o automaticamente ejecutando:
+```bash
+sed -i 's|./.data:/.data|./.data-reduced:/.data|' ./scripts/compose/main.go # linux
+sed -i '' 's|./.data:/.data|./.data-reduced:/.data|' ./scripts/compose/main.go # osx
+```
+
+Luego, regeneramos el compose:
+```bash
+make write-compose
+```
+
+Luego de ejecutar el sistema, podemos adaptar la seccion de [comparacion de resultados](#comparacion-de-resultados) para utilizar el dataset reducido.

--- a/cmd/group-by/main.go
+++ b/cmd/group-by/main.go
@@ -123,10 +123,9 @@ func (h *handler) Conclude(ch *middleware.Channel) error {
 	}
 
 	batch := middleware.Batch[middleware.GameStat]{
-		Data:     []middleware.GameStat{},
-		ClientID: 1,
-		BatchID:  0,
-		EOF:      false,
+		Data:    []middleware.GameStat{},
+		BatchID: 0,
+		EOF:     false,
 	}
 
 	games := slices.Collect(maps.Values(h.games))

--- a/cmd/group-joiner/main.go
+++ b/cmd/group-joiner/main.go
@@ -60,10 +60,9 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte, partition int
 	h.sequencer[partition].Mark(batch.BatchID, batch.EOF)
 
 	b := middleware.Batch[middleware.GameStat]{
-		Data:     batch.Data,
-		ClientID: batch.ClientID,
-		BatchID:  h.lastBatchId,
-		EOF:      false,
+		Data:    batch.Data,
+		BatchID: h.lastBatchId,
+		EOF:     false,
 	}
 
 	err = ch.Send(b, "", h.output)

--- a/cmd/more-than-n-reviews/main.go
+++ b/cmd/more-than-n-reviews/main.go
@@ -63,6 +63,14 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte) error {
 
 func (h *handler) conclude(ch *middleware.Channel) error {
 	results := slices.Collect(maps.Values(h.results))
+	if len(results) == 0 {
+		p := protocol.Q4Results{
+			EOF: true,
+		}
+
+		return ch.SendAny(p, "", middleware.Results)
+	}
+
 	for i, res := range results {
 		p := protocol.Q4Results{
 			AppID: res.AppID,

--- a/cmd/more-than-n-reviews/main.go
+++ b/cmd/more-than-n-reviews/main.go
@@ -64,7 +64,7 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte) error {
 func (h *handler) conclude(ch *middleware.Channel) error {
 	results := slices.Collect(maps.Values(h.results))
 	if len(results) == 0 {
-		p := protocol.Q4Results{
+		p := protocol.Q4Result{
 			EOF: true,
 		}
 

--- a/middleware/messages.go
+++ b/middleware/messages.go
@@ -41,10 +41,9 @@ type GameStat struct {
 }
 
 type Batch[T any] struct {
-	Data     []T
-	ClientID int
-	BatchID  int
-	EOF      bool
+	Data    []T
+	BatchID int
+	EOF     bool
 }
 
 func Serialize(v any) ([]byte, error) {

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-const GAMES = 1000
+const GAMES = 10000
 
 func main() {
 	gamesIds := make(map[string]struct{})

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+)
+
+const GAMES = 1000
+
+func main() {
+	gamesIds := make([]string, 0)
+
+	gamesIds = writeGames(gamesIds)
+	writeReviews(gamesIds)
+}
+
+func writeGames(gamesIds []string) []string {
+	fullGames, err := os.Open(".data/games.csv")
+	if err != nil {
+		fmt.Printf("Error opening games file: %v", err)
+	}
+	defer fullGames.Close()
+
+	reduced, err := os.OpenFile(".data/games-reduced.csv", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("Failed to open reduced games file: %v", err)
+	}
+	defer reduced.Close()
+
+	r := csv.NewReader(fullGames)
+	r.FieldsPerRecord = 40
+	w := csv.NewWriter(reduced)
+	line := 0
+
+	for line < GAMES {
+		record, err := r.Read()
+		if err != nil {
+			fmt.Printf("Failed to read record: %v", err)
+		}
+
+		err = w.Write(record)
+		if err != nil {
+			fmt.Printf("Failed to write record: %v", err)
+		}
+		w.Flush()
+
+		line += 1
+
+		if line == 1 {
+			continue
+		}
+
+		id := record[0]
+		gamesIds = append(gamesIds, id)
+	}
+
+	return gamesIds
+}
+
+func writeReviews(gamesIds []string) {
+
+	fullReviews, err := os.Open(".data/reviews.csv")
+	if err != nil {
+		fmt.Printf("Error opening reviews file: %v", err)
+	}
+	defer fullReviews.Close()
+
+	reduced, err := os.OpenFile(".data/reviews-reduced.csv", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Printf("Failed to open reduced games file: %v", err)
+	}
+	defer reduced.Close()
+
+	r := csv.NewReader(fullReviews)
+	r.FieldsPerRecord = 5
+	w := csv.NewWriter(reduced)
+
+	// write header
+	record, err := r.Read()
+	if err != nil {
+		fmt.Printf("Failed to read record: %v", err)
+	}
+	err = w.Write(record)
+	if err != nil {
+		fmt.Printf("Failed to write record: %v", err)
+	}
+	w.Flush()
+
+	for {
+		record, err := r.Read()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			fmt.Printf("Failed to read record: %v", err)
+		}
+
+		if slices.Contains(gamesIds, record[0]) {
+			err = w.Write(record)
+			if err != nil {
+				fmt.Printf("Failed to write record: %v", err)
+			}
+			w.Flush()
+		}
+	}
+}

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"maps"
 	"os"
-	"slices"
 )
 
 const GAMES = 1000
@@ -33,7 +31,7 @@ func writeGames(gamesIds map[string]struct{}) {
 	defer reduced.Close()
 
 	r := csv.NewReader(fullGames)
-	r.FieldsPerRecord = 40
+	r.FieldsPerRecord = -1
 	w := csv.NewWriter(reduced)
 	line := 0
 
@@ -73,7 +71,6 @@ func writeGames(gamesIds map[string]struct{}) {
 
 func writeReviews(gamesIds map[string]struct{}) {
 
-	ids := slices.Collect(maps.Keys(gamesIds))
 	fullReviews, err := os.Open(".data/reviews.csv")
 	if err != nil {
 		fmt.Printf("Error opening reviews file: %v", err)
@@ -87,7 +84,7 @@ func writeReviews(gamesIds map[string]struct{}) {
 	defer reduced.Close()
 
 	r := csv.NewReader(fullReviews)
-	r.FieldsPerRecord = 5
+	r.FieldsPerRecord = -1
 	w := csv.NewWriter(reduced)
 
 	// write header
@@ -110,7 +107,7 @@ func writeReviews(gamesIds map[string]struct{}) {
 			fmt.Printf("Failed to read record: %v", err)
 		}
 
-		if slices.Contains(ids, record[0]) {
+		if _, ok := gamesIds[record[0]]; ok {
 			err = w.Write(record)
 			if err != nil {
 				fmt.Printf("Failed to write record: %v", err)

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"distribuidos/tp1/utils"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -24,7 +25,10 @@ func writeGames(gamesIds map[string]struct{}) {
 	}
 	defer fullGames.Close()
 
-	reduced, err := os.OpenFile(".data/games-reduced.csv", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	err = os.MkdirAll(".data-reduced", os.ModePerm)
+	utils.Expect(err, "Failed to create output directory")
+
+	reduced, err := os.Create(".data-reduced/games.csv")
 	if err != nil {
 		fmt.Printf("Failed to open reduced games file: %v\n", err)
 	}
@@ -77,7 +81,10 @@ func writeReviews(gamesIds map[string]struct{}) {
 	}
 	defer fullReviews.Close()
 
-	reduced, err := os.OpenFile(".data/reviews-reduced.csv", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	err = os.MkdirAll(".data-reduced", os.ModePerm)
+	utils.Expect(err, "Failed to create output directory")
+
+	reduced, err := os.Create(".data-reduced/reviews.csv")
 	if err != nil {
 		fmt.Printf("Failed to open reduced reviews file: %v\n", err)
 	}

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 )
@@ -12,13 +13,13 @@ import (
 const GAMES = 1000
 
 func main() {
-	gamesIds := make([]string, 0)
+	gamesIds := make(map[string]struct{})
 
-	gamesIds = writeGames(gamesIds)
+	writeGames(gamesIds)
 	writeReviews(gamesIds)
 }
 
-func writeGames(gamesIds []string) []string {
+func writeGames(gamesIds map[string]struct{}) {
 	fullGames, err := os.Open(".data/games.csv")
 	if err != nil {
 		fmt.Printf("Error opening games file: %v", err)
@@ -66,14 +67,13 @@ func writeGames(gamesIds []string) []string {
 		}
 
 		id := record[0]
-		gamesIds = append(gamesIds, id)
+		gamesIds[id] = struct{}{}
 	}
-
-	return gamesIds
 }
 
-func writeReviews(gamesIds []string) {
+func writeReviews(gamesIds map[string]struct{}) {
 
+	ids := slices.Collect(maps.Keys(gamesIds))
 	fullReviews, err := os.Open(".data/reviews.csv")
 	if err != nil {
 		fmt.Printf("Error opening reviews file: %v", err)
@@ -110,7 +110,7 @@ func writeReviews(gamesIds []string) {
 			fmt.Printf("Failed to read record: %v", err)
 		}
 
-		if slices.Contains(gamesIds, record[0]) {
+		if slices.Contains(ids, record[0]) {
 			err = w.Write(record)
 			if err != nil {
 				fmt.Printf("Failed to write record: %v", err)

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -20,13 +20,13 @@ func main() {
 func writeGames(gamesIds map[string]struct{}) {
 	fullGames, err := os.Open(".data/games.csv")
 	if err != nil {
-		fmt.Printf("Error opening games file: %v", err)
+		fmt.Printf("Error opening games file: %v\n", err)
 	}
 	defer fullGames.Close()
 
 	reduced, err := os.OpenFile(".data/games-reduced.csv", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Printf("Failed to open reduced games file: %v", err)
+		fmt.Printf("Failed to open reduced games file: %v\n", err)
 	}
 	defer reduced.Close()
 
@@ -38,23 +38,23 @@ func writeGames(gamesIds map[string]struct{}) {
 	// write header
 	record, err := r.Read()
 	if err != nil {
-		fmt.Printf("Failed to read record: %v", err)
+		fmt.Printf("Failed to read record: %v\n", err)
 	}
 	err = w.Write(record)
 	if err != nil {
-		fmt.Printf("Failed to write record: %v", err)
+		fmt.Printf("Failed to write record: %v\n", err)
 	}
 	w.Flush()
 
 	for line < GAMES {
 		record, err := r.Read()
 		if err != nil {
-			fmt.Printf("Failed to read record: %v", err)
+			fmt.Printf("Failed to read record: %v\n", err)
 		}
 
 		err = w.Write(record)
 		if err != nil {
-			fmt.Printf("Failed to write record: %v", err)
+			fmt.Printf("Failed to write record: %v\n", err)
 		}
 		w.Flush()
 
@@ -73,13 +73,13 @@ func writeReviews(gamesIds map[string]struct{}) {
 
 	fullReviews, err := os.Open(".data/reviews.csv")
 	if err != nil {
-		fmt.Printf("Error opening reviews file: %v", err)
+		fmt.Printf("Error opening reviews file: %v\n", err)
 	}
 	defer fullReviews.Close()
 
 	reduced, err := os.OpenFile(".data/reviews-reduced.csv", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		fmt.Printf("Failed to open reduced games file: %v", err)
+		fmt.Printf("Failed to open reduced reviews file: %v\n", err)
 	}
 	defer reduced.Close()
 
@@ -90,11 +90,11 @@ func writeReviews(gamesIds map[string]struct{}) {
 	// write header
 	record, err := r.Read()
 	if err != nil {
-		fmt.Printf("Failed to read record: %v", err)
+		fmt.Printf("Failed to read record: %v\n", err)
 	}
 	err = w.Write(record)
 	if err != nil {
-		fmt.Printf("Failed to write record: %v", err)
+		fmt.Printf("Failed to write record: %v\n", err)
 	}
 	w.Flush()
 
@@ -104,13 +104,13 @@ func writeReviews(gamesIds map[string]struct{}) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			fmt.Printf("Failed to read record: %v", err)
+			fmt.Printf("Failed to read record: %v\n", err)
 		}
 
 		if _, ok := gamesIds[record[0]]; ok {
 			err = w.Write(record)
 			if err != nil {
-				fmt.Printf("Failed to write record: %v", err)
+				fmt.Printf("Failed to write record: %v\n", err)
 			}
 			w.Flush()
 		}

--- a/scripts/reduce/main.go
+++ b/scripts/reduce/main.go
@@ -36,6 +36,17 @@ func writeGames(gamesIds []string) []string {
 	w := csv.NewWriter(reduced)
 	line := 0
 
+	// write header
+	record, err := r.Read()
+	if err != nil {
+		fmt.Printf("Failed to read record: %v", err)
+	}
+	err = w.Write(record)
+	if err != nil {
+		fmt.Printf("Failed to write record: %v", err)
+	}
+	w.Flush()
+
 	for line < GAMES {
 		record, err := r.Read()
 		if err != nil {

--- a/scripts/solve.py
+++ b/scripts/solve.py
@@ -1,11 +1,17 @@
 import pandas as pd
 import os
+import argparse
 
 from pandas import DataFrame
 
+parser = argparse.ArgumentParser()
+parser.add_argument('input')
+parser.add_argument('output')
+args = parser.parse_args()
+
 # games
 
-games = pd.read_csv('.data/games.csv')
+games = pd.read_csv(f'{args.input}/games.csv')
 games_columns = ['AppID', 'Name', 'Windows', 'Mac', 'Linux', 'Genres', 'Release date', 'Average playtime forever', 'Positive', 'Negative']
 games = games.filter(games_columns, axis="columns").dropna()
 games["Genres"] = games["Genres"].str.lower()
@@ -27,17 +33,17 @@ except:
 # Q1
 
 q1_count = games[["Linux", "Mac", "Windows"]].sum().to_frame().transpose()
-q1_count.to_csv(".py-results/1.csv", header=True, index=False)
+q1_count.to_csv(f"{args.output}/1.csv", header=True, index=False)
 
 # Q2
 
 q1_games = games_indie_2010.filter(["AppID", "Name", "Average playtime forever"], axis="columns")
 q1_top = q1_games.sort_values("Average playtime forever", ascending=False).head(10)
-q1_top.to_csv(".py-results/2.csv", header=True, index=False)
+q1_top.to_csv(f"{args.output}/2.csv", header=True, index=False)
 
 # reviews
 
-reviews = pd.read_csv('.data/reviews.csv')
+reviews = pd.read_csv(f'{args.input}/reviews.csv')
 reviews_columns = ['app_id', 'review_text', 'review_score']
 reviews = reviews.filter(reviews_columns, axis="columns").dropna()
 reviews['review_text'] = reviews['review_text'].astype(str)
@@ -50,7 +56,7 @@ reviews_negative: DataFrame = reviews[reviews["review_score"] == -1] # type: ign
 print("Reviews Negative:", reviews_negative.shape[0])
 
 # We use another dataset, which was filtered in Go
-reviews_negative_ingles = pd.read_csv('.data/reviews-english-negative.csv')
+reviews_negative_ingles = pd.read_csv(f'{args.input}/reviews-english-negative.csv')
 reviews_negative_ingles = reviews_negative_ingles.filter(reviews_columns, axis="columns").dropna()
 print("Reviews Negative Ingles:", reviews_negative_ingles.shape[0])
 
@@ -68,17 +74,17 @@ def group(games, reviews) -> DataFrame:
 
 q3_grouped = group(games_indie, reviews_positive)
 q3_top = q3_grouped.sort_values("Reviews", ascending=False).head(5)
-q3_top.to_csv(".py-results/3.csv", header=True, index=True)
+q3_top.to_csv(f"{args.output}/3.csv", header=True, index=True)
 
 # Q4
 
 q4_grouped = group(games_shooter, reviews_negative_ingles)
 q4_filtered = q4_grouped[q4_grouped["Reviews"] > 5000]
-q4_filtered.sort_index().to_csv(".py-results/4.csv", header=True, index=True)
+q4_filtered.sort_index().to_csv(f"{args.output}/4.csv", header=True, index=True)
 
 # Q5
 
 q5_grouped = group(games_shooter, reviews_negative)
 percentile = q5_grouped["Reviews"].quantile(0.90)
 q5_top = q5_grouped[q5_grouped["Reviews"] >= percentile]
-q5_top.sort_index().to_csv(".py-results/5.csv", header=True, index=True)
+q5_top.sort_index().to_csv(f"{args.output}/5.csv", header=True, index=True)


### PR DESCRIPTION
Toma los primeros n juegos, y todas las reseñas de esos juegos. No es lo más eficiente, pero dado que se corre una sola vez no sé qué tan necesario sea optimizar (igualmente acepto sugerencias si las tienen).

~~Observaciones:~~
~~- Ejecuta todas las consultas (casi) sin problemas~~
~~- El gateway tiene un error de parseo con el app_id de las reseñas (no sé bien por qué)~~
~~- El script de python tiene un error de tipos y no puede ejecutar q1~~

~~No sé si al pasar de un archivo al otro se cambian formatos. Si es así, puedo probar otra forma de escribir las líneas.~~

**EDIT**: ya compila todo bien sin errores, pero hay problemas con el EOF. 

Q4 nunca termina (asumo que nunca recibe el EOF o le falta algún paquete en el medio), y depende de la ejecución q3 y q5 tampoco terminan, así que debe ser algo de las reseñas. Sigo probando, pero lo dejo para que tengamos en cuenta (estuve probando con 1000 juegos, que son aproximadamente 54000 reseñas).

**UPDATE**: probando con 10.000 juegos funciona todo bien. Habría que analizar por qué con menos reseñas se "pierden" paquetes, pero no lo vería como prioridad.