### PR TITLE
Avoid steplock behaviour in restarters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ compose-up: compose-down docker-build
 
 compose-down:
 	docker compose -f compose.yaml stop -t 2
-	docker compose -f compose.yaml down
+	docker compose -f compose.yaml down --remove-orphans
 .PHONY: compose-down
 
 compose-logs:

--- a/restarter-protocol/restarter.go
+++ b/restarter-protocol/restarter.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"os"
 	"os/exec"
@@ -127,6 +128,9 @@ func (r *Restarter) Start(ctx context.Context) error {
 func (r *Restarter) StartMonitoring(ctx context.Context) {
 	for _, node := range r.nodes {
 		r.wg.Add(1)
+
+		time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+
 		go func(nodeName string) {
 			defer r.wg.Done()
 			r.monitorNode(ctx, nodeName, utils.NODE_PORT)
@@ -139,12 +143,11 @@ func (r *Restarter) StartMonitoring(ctx context.Context) {
 }
 
 func (r *Restarter) monitorNode(ctx context.Context, containerName string, port int) {
-	ticker := time.NewTicker(time.Second * 5)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-time.After(time.Duration(rand.Intn(2000)+1000) * time.Millisecond):
 			msg := KeepAlive{}
 			addr, _ := utils.GetUDPAddr(containerName, port)
 			err := r.safeSend(ctx, msg, addr)

--- a/restarter-protocol/restarter.go
+++ b/restarter-protocol/restarter.go
@@ -147,7 +147,7 @@ func (r *Restarter) monitorNode(ctx context.Context, containerName string, port 
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(time.Duration(rand.Intn(2000)+1000) * time.Millisecond):
+		case <-time.After(time.Duration(rand.Intn(4000)+3000) * time.Millisecond):
 			msg := KeepAlive{}
 			addr, _ := utils.GetUDPAddr(containerName, port)
 			err := r.safeSend(ctx, msg, addr)


### PR DESCRIPTION
Se empezaron a crashear los restartes. Creo que tenian mucho uso de red. Le agregue algunos randoms para mitigar esto, asi no salen todos los mensajes al mismo tiempo