### PR TITLE
Add Stress build tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM golang:1.23 AS builder
 
+ARG GO_TAGS=""
+
 WORKDIR /build
 
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o .build/ ./cmd/...
+RUN CGO_ENABLED=0 go build -tags "${GO_TAGS}" -o .build/ ./cmd/...
 
 FROM alpine:latest
 RUN apk add docker

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ deps:
 	go mod tidy
 .PHONY: deps
 
+clean:
+	sudo rm -rf .backup
+	sudo rm -rf .results-*
+.PHONY: clean
+
 build: deps
 	go build -o .build/ ./cmd/...
 

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ compose-logs:
 	docker compose -f compose.yaml logs -f
 .PHONY: compose-logs
 
-run: docker-build compose-down compose-up compose-logs
+run: clean docker-build compose-down compose-up compose-logs
 .PHONY: run
 
-run-stress: docker-build-stress compose-down compose-up compose-logs
+run-stress: clean docker-build-stress compose-down compose-up compose-logs
 .PHONY: run-stress
 
 write-compose:

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ deps:
 .PHONY: deps
 
 clean:
-	sudo rm -rf .backup
-	sudo rm -rf .results-*
+	docker run --rm -v $(shell pwd):/work -w /work alpine sh -c 'rm -rf .backup .results-*'
 .PHONY: clean
 
 build: deps

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ docker-build:
 	docker build -t "tp1:latest" .
 .PHONY: compose-build
 
-compose-up: compose-down docker-build
+docker-build-stress:
+	docker build --build-arg GO_TAGS=stress -t "tp1:latest" .
+.PHONY: compose-build
+
+compose-up:
 	docker compose -f compose.yaml up -d
 .PHONY: compose-up
 
@@ -25,6 +29,12 @@ compose-down:
 compose-logs:
 	docker compose -f compose.yaml logs -f
 .PHONY: compose-logs
+
+run: docker-build compose-down compose-up compose-logs
+.PHONY: run
+
+run-stress: docker-build-stress compose-down compose-up compose-logs
+.PHONY: run-stress
 
 write-compose:
 	go run ./scripts/compose > compose.yaml

--- a/cmd/games-per-platform-joiner/main.go
+++ b/cmd/games-per-platform-joiner/main.go
@@ -132,6 +132,8 @@ func (h *handler) handlePartialResult(ch *middleware.Channel, data []byte, parti
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.joiner.EOF() {
 		count := map[Platform]int{
 			Windows: int(windowsCounter),
@@ -151,6 +153,8 @@ func (h *handler) handlePartialResult(ch *middleware.Channel, data []byte, parti
 		if err != nil {
 			return err
 		}
+
+		utils.MaybeExit(0.50)
 
 		ch.Finish()
 		return nil

--- a/cmd/games-per-platform/main.go
+++ b/cmd/games-per-platform/main.go
@@ -136,6 +136,8 @@ func (h *handler) handleGame(ch *middleware.Channel, data []byte) (err error) {
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.sequencer.EOF() {
 		count := map[Platform]int{
 			Windows: int(windowsCounter),
@@ -151,6 +153,8 @@ func (h *handler) handleGame(ch *middleware.Channel, data []byte) (err error) {
 		if err != nil {
 			return err
 		}
+
+		utils.MaybeExit(0.50)
 
 		ch.Finish()
 	}

--- a/cmd/group-by/main.go
+++ b/cmd/group-by/main.go
@@ -151,7 +151,7 @@ func (h *handler) handleReview(ch *middleware.Channel, data []byte) error {
 		}
 	}
 
-	utils.MaybeExit(0.001)
+	utils.MaybeExit(0.0001)
 
 	if h.reviewSequencer.EOF() {
 		log.Infof("Received review EOF")

--- a/cmd/group-by/main.go
+++ b/cmd/group-by/main.go
@@ -92,12 +92,16 @@ func (h *handler) handleGame(ch *middleware.Channel, data []byte) error {
 		err = h.diskMap.Rename(snapshot, g.AppID, g.Name)
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.gameSequencer.EOF() {
 		log.Infof("Received game EOF")
 	}
 
 	if h.gameSequencer.EOF() && h.reviewSequencer.EOF() {
-		return h.conclude(ch)
+		err = h.conclude(ch)
+		utils.MaybeExit(0.50)
+		return err
 	}
 
 	return nil
@@ -147,12 +151,16 @@ func (h *handler) handleReview(ch *middleware.Channel, data []byte) error {
 		}
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.reviewSequencer.EOF() {
 		log.Infof("Received review EOF")
 	}
 
 	if h.reviewSequencer.EOF() && h.gameSequencer.EOF() {
-		return h.conclude(ch)
+		err := h.conclude(ch)
+		utils.MaybeExit(0.50)
+		return err
 	}
 
 	return nil

--- a/cmd/group-joiner/main.go
+++ b/cmd/group-joiner/main.go
@@ -124,6 +124,9 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte, partition int
 	for _, v := range h.sequencers {
 		allEof = allEof && v.EOF()
 	}
+
+	utils.MaybeExit(0.001)
+
 	if allEof {
 		b := middleware.Batch[middleware.GameStat]{
 			BatchID: int(id),
@@ -134,6 +137,9 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte, partition int
 			return err
 		}
 		ch.Finish()
+
+		utils.MaybeExit(0.50)
+
 	}
 
 	return nil

--- a/cmd/percentile/main.go
+++ b/cmd/percentile/main.go
@@ -102,12 +102,17 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte) error {
 		}
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.sequencer.EOF() {
 		err = h.conclude(ch, batch.Data)
 		if err != nil {
 			return err
 		}
 		ch.Finish()
+
+		utils.MaybeExit(0.50)
+
 	}
 
 	return nil

--- a/cmd/top-n-historic-avg-joiner/main.go
+++ b/cmd/top-n-historic-avg-joiner/main.go
@@ -91,8 +91,11 @@ func (h *handler) handlePartialResult(ch *middleware.Channel, data []byte, parti
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.joiner.EOF() {
 		log.Infof("Received all partial results")
+		utils.MaybeExit(0.50)
 		return h.conclude(ch)
 	}
 	return nil

--- a/cmd/top-n-historic-avg/main.go
+++ b/cmd/top-n-historic-avg/main.go
@@ -85,11 +85,15 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte) error {
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.sequencer.EOF() {
 		err := h.conclude(ch)
 		if err != nil {
 			return err
 		}
+
+		utils.MaybeExit(0.50)
 
 		ch.Finish()
 	}

--- a/cmd/top-n-reviews-joiner/main.go
+++ b/cmd/top-n-reviews-joiner/main.go
@@ -85,9 +85,13 @@ func (h *handler) handlePartialResult(ch *middleware.Channel, data []byte, parti
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.joiner.EOF() {
 		log.Infof("Received all partial results")
-		return h.conclude(ch)
+		err = h.conclude(ch)
+		utils.MaybeExit(0.50)
+		return err
 	}
 	return nil
 }

--- a/cmd/top-n-reviews/main.go
+++ b/cmd/top-n-reviews/main.go
@@ -81,12 +81,15 @@ func (h *handler) handleBatch(ch *middleware.Channel, data []byte) error {
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	if h.sequencer.EOF() {
 		err := h.conclude(ch)
 		if err != nil {
 			return err
 		}
 
+		utils.MaybeExit(0.50)
 		ch.Finish()
 	}
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,8 +13,6 @@ services:
       interval: 5s
       timeout: 5s
       retries: 3
-    logging:
-      driver: none
   gateway:
     container_name: gateway
     image: tp1:latest

--- a/database/snapshot.go
+++ b/database/snapshot.go
@@ -215,6 +215,8 @@ func (s *Snapshot) ApplyCommit() error {
 		return err
 	}
 
+	utils.MaybeExit(0.001)
+
 	err = os.RemoveAll(s.root)
 	if err != nil {
 		return err
@@ -248,6 +250,8 @@ func (s *Snapshot) commitFile(modified_path string, info fs.DirEntry, err error)
 		}
 		return os.Rename(modified_path, original_path)
 	}
+
+	utils.MaybeExit(0.001)
 
 	return nil
 }
@@ -297,6 +301,8 @@ func (s *Snapshot) commitAppendFile(modified_path string, info fs.DirEntry, err 
 	if err != nil {
 		return err
 	}
+
+	utils.MaybeExit(0.001)
 
 	return os.Remove(modified_path)
 }

--- a/database/snapshot.go
+++ b/database/snapshot.go
@@ -215,8 +215,6 @@ func (s *Snapshot) ApplyCommit() error {
 		return err
 	}
 
-	utils.MaybeExit(0.001)
-
 	err = os.RemoveAll(s.root)
 	if err != nil {
 		return err
@@ -250,8 +248,6 @@ func (s *Snapshot) commitFile(modified_path string, info fs.DirEntry, err error)
 		}
 		return os.Rename(modified_path, original_path)
 	}
-
-	utils.MaybeExit(0.001)
 
 	return nil
 }
@@ -301,8 +297,6 @@ func (s *Snapshot) commitAppendFile(modified_path string, info fs.DirEntry, err 
 	if err != nil {
 		return err
 	}
-
-	utils.MaybeExit(0.001)
 
 	return os.Remove(modified_path)
 }

--- a/middleware/node.go
+++ b/middleware/node.go
@@ -34,7 +34,7 @@ func NewNode[T Handler](config Config[T], rabbit *amqp.Connection) (*Node[T], er
 		return nil, err
 	}
 
-	err = ch.Qos(1000, 0, false)
+	err = ch.Qos(1, 0, false)
 	if err != nil {
 		return nil, err
 	}

--- a/scripts/compose/main.go
+++ b/scripts/compose/main.go
@@ -98,8 +98,6 @@ func generateRabbit() {
 	fmt.Println("      interval: 5s")
 	fmt.Println("      timeout: 5s")
 	fmt.Println("      retries: 3")
-	fmt.Println("    logging:")
-	fmt.Println("      driver: none")
 }
 
 func generateGateway() {

--- a/utils/stress_off.go
+++ b/utils/stress_off.go
@@ -1,0 +1,5 @@
+//go:build !stress
+
+package utils
+
+func MaybeExit(p float32) {}

--- a/utils/stress_on.go
+++ b/utils/stress_on.go
@@ -1,0 +1,14 @@
+//go:build stress
+
+package utils
+
+import (
+	"math/rand"
+	"os"
+)
+
+func MaybeExit(p float32) {
+	if rand.Float32() < p {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Agrega la funcion `MaybeExit(p)`, que mata al proceso con probabilidad p. Esta funcion se va a compilar condicionalmente si se usa el build tag `stress`. https://pkg.go.dev/go/build#hdr-Build_Constraints

Agregue 2 recetas al Makefile:
- `run`: Ejecuta normalmente
- `run-stress`: Ejecuta con el build tag `stress`. Esto hace que los nodos se caigan regularmente. Nos permite probar que el sistema funciona bien con tolerancia a fallas